### PR TITLE
Upgrades Hassio CLI to v2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Install CLI
 ARG BUILD_ARCH
-ARG HASSIO_CLI_VERSION=2.2.0
+ARG HASSIO_CLI_VERSION=2.3.0
 RUN apk add --no-cache curl \
     && curl -Lso /usr/bin/hassio https://github.com/home-assistant/hassio-cli/releases/download/${HASSIO_CLI_VERSION}/hassio_${BUILD_ARCH} \
     && chmod a+x /usr/bin/hassio \


### PR DESCRIPTION
Upgrades Hassio CLI to v2.3.0

https://github.com/home-assistant/hassio-cli/releases/tag/2.3.0