### PR TITLE
Upgrade CLI to 4.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Install CLI
 ARG BUILD_ARCH
-ARG HASSIO_CLI_VERSION=3.1.1
+ARG CLI_VERSION=4.0.0
 RUN apk add --no-cache curl \
-    && curl -Lso /usr/bin/hassio https://github.com/home-assistant/hassio-cli/releases/download/${HASSIO_CLI_VERSION}/hassio_${BUILD_ARCH} \
-    && chmod a+x /usr/bin/hassio \
+    && curl -Lso /usr/bin/ha https://github.com/home-assistant/cli/releases/download/${CLI_VERSION}/ha_${BUILD_ARCH} \
+    && chmod a+x /usr/bin/ha \
     && apk del curl
 
 COPY cli.sh /bin/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://dev.azure.com/home-assistant/Home%20Assistant/_apis/build/status/home-assistant.hassos-cli?branchName=master)](https://dev.azure.com/home-assistant/Home%20Assistant/_build/latest?definitionId=5&branchName=master)
 
-# Hass.io CLI for HassOS
+# CLI for the Home Assistant Operating System
 
-This is for HassOS and is the login shell for Hass.io based systems.
+This is for the Home Assistant Operating System and is the login shell.

--- a/cli.sh
+++ b/cli.sh
@@ -4,12 +4,12 @@ cat /etc/welcome.txt
 
 # Set Token
 # shellcheck disable=SC2155
-export HASSIO_TOKEN=$(cat /etc/machine-id)
+export SUPERVISOR_TOKEN=$(cat /etc/machine-id)
 
 # Run CLI
 COMMAND=""
 while true; do
-    read -rp "hassio > " COMMAND
+    read -rp "ha > " COMMAND
 
     # Abort to host?
     if [ "$COMMAND" == "login" ]; then
@@ -19,6 +19,6 @@ while true; do
     fi
 
     # shellcheck disable=SC2086
-    hassio $COMMAND
+    ha $COMMAND
     echo ""
 done


### PR DESCRIPTION
Upgrades the CLI to 4.0.0.

This version of the CLI contains the re-branding.
The general runtime is adjusted to reflect the upstream changes.