### PR TITLE
Update Home Assistant CLI to v4.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Install CLI
 ARG BUILD_ARCH
-ARG CLI_VERSION=4.0.1
+ARG CLI_VERSION=4.1.0
 RUN apk add --no-cache curl \
     && curl -Lso /usr/bin/ha https://github.com/home-assistant/cli/releases/download/${CLI_VERSION}/ha_${BUILD_ARCH} \
     && chmod a+x /usr/bin/ha \


### PR DESCRIPTION
Release notes: <https://github.com/home-assistant/cli/releases/tag/4.1.0>